### PR TITLE
Consolidate proxy options and update fluent-bit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,7 @@ COPY .git Makefile go.* *.go /work/
 COPY pkg/ /work/pkg/
 RUN make bin/audit-forwarder
 
-# Need to keep fluent-bit version below 1.7.5 for now,
-# due to bug https://github.com/fluent/fluent-bit/issues/3699
-FROM fluent/fluent-bit:1.8.2-debug
+FROM fluent/fluent-bit:1.8.10-debug
 
 COPY --from=builder /work/bin/audit-forwarder /fluent-bit/bin/
 COPY fluent-bit.conf /fluent-bit/etc/

--- a/README.md
+++ b/README.md
@@ -9,9 +9,18 @@ This is a small piece of software that is intended to run as sidecar in an out-o
 - There has to be a corresponding `kubernetes-audit-tailer` service and pod in the cluster that receives the audit data and makes it available to a cluster logging solution, e.g. by writing it to its stdout so that it appears as container log
 - We use fluent-bit with the `forward` out plugin as forwarding agent because it is built for the task of reliably forwarding log data. There needs to be a corresponding fluent-bit or fluentd running in the `kubernetes-audit-tailer` pod to receive the data
 
-### Use with konnectivity tunnel (UDS proxy or mTLS proxy with http-connect)
+### Use with proxy (mTLS proxy with http-connect)
 
-If connectivity between the apiserver and cluster is done with a [konnectivity proxy](https://github.com/kubernetes-sigs/apiserver-network-proxy), auditforwarder can use this. There are two variants supported:
+In some scenarios it is necessary to use a proxy to communicate from the control plane to the cluster:
+
+- When a [konnectivity proxy](https://github.com/kubernetes-sigs/apiserver-network-proxy) is used to connect from the control plane to the cluster. Konnectivity comes in two flavours:
+  - Using a UDS proxy
+  - Using a mTLS proxy with http-connect
+- When the Gardener reversed-vpn feature is used
+
+Auditforwarder can use either UDS or mTLS proxy; konnectivity or Gardener reversed-vpn look the same from a user perspective (only the proxy hostname is different) so they get treated the same.
+
+FIXME describe this better
 
 - A UDS proxy using the http connect method, running in another sidecar of the apiserver. Details on how this gets invoked are within the konnectivity test case (see next section).
 - A mTLS proxy using http connect, running in a seperate pod from the kube-apiserver. The method to use this is much the same as with the UDS proxy; there are seperate command options to specify the proxy host and port.

--- a/kind/kustomize-auditforwarder-konnectivity/kube-apiserver_patch.yaml
+++ b/kind/kustomize-auditforwarder-konnectivity/kube-apiserver_patch.yaml
@@ -2,7 +2,7 @@
 - op: add
   path: /spec/containers/1
   value:
-    image: ghcr.io/metal-stack/audit-forwarder:pr-Konnectivity_mTLS
+    image: ghcr.io/metal-stack/audit-forwarder:pr-consolidate-proxies
     imagePullPolicy: Always
     name: audit-forwarder
     env:

--- a/kind/kustomize-auditforwarder-splunk/kube-apiserver_patch.yaml
+++ b/kind/kustomize-auditforwarder-splunk/kube-apiserver_patch.yaml
@@ -1,7 +1,7 @@
 - op: add
   path: /spec/containers/1
   value:
-    image: ghcr.io/metal-stack/audit-forwarder:pr-update-fluent-bit
+    image: ghcr.io/metal-stack/audit-forwarder:pr-consolidate-proxies
     imagePullPolicy: Always
     name: audit-forwarder
     env:

--- a/kind/kustomize-auditforwarder/kube-apiserver_patch.yaml
+++ b/kind/kustomize-auditforwarder/kube-apiserver_patch.yaml
@@ -1,7 +1,7 @@
 - op: add
   path: /spec/containers/1
   value:
-    image: ghcr.io/metal-stack/audit-forwarder:pr-update-fluent-bit
+    image: ghcr.io/metal-stack/audit-forwarder:pr-consolidate-proxies
     imagePullPolicy: Always
     name: audit-forwarder
     env:

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/metal-stack/audit-forwarder/pkg/konnectivityproxy"
+	"github.com/metal-stack/audit-forwarder/pkg/proxy"
 	"github.com/metal-stack/v"
 
 	"github.com/go-playground/validator/v10"
@@ -52,7 +52,7 @@ var (
 	forwarderProcess    *os.Process
 	secretCronID        cron.EntryID
 	serviceCronID       cron.EntryID
-	konnectivityProxy   *konnectivityproxy.Proxy
+	clusterProxy        *proxy.Proxy
 )
 
 // CronLogger is used for logging within the cron function.
@@ -139,10 +139,10 @@ func init() {
 	cmd.Flags().StringP("log-level", "L", "info", "sets the application log level")
 	cmd.Flags().StringP("fluent-log-level", "O", "info", "sets the log level for the fluent-bit command")
 	cmd.Flags().StringP("konnectivity-uds-socket", "u", "", "If set, try and connect through this konnectivity UDS socket. Expected method is http-connect. Mutually exclusive with proxy-host.")
-	cmd.Flags().StringP("proxy-host", "p", "", "If set, try and connect through this konnectivity mTLS proxy at the given destination. Expected method is http-connect. Mutually exclusive with konectivity-uds-socket.")
-	cmd.Flags().StringP("proxy-port", "P", "9443", "Port of the konnectivity mTLS proxy specified with proxy-host.")
-	cmd.Flags().String("proxy-ca-file", "/konnectivity-proxy/ca/ca.crt", "the path to the CA file for checking the konnectivity-proxy mTLS server certificate")
-	cmd.Flags().String("proxy-client-crt-file", "/konnectivity-proxy/client/tls.crt", "the path to the proxy client certificate used to authenticate to the konnectivity-proxy mTLS server")
+	cmd.Flags().StringP("proxy-host", "p", "", "If set, try and connect through this mTLS proxy at the given destination. Expected method is http-connect. Mutually exclusive with konectivity-uds-socket.")
+	cmd.Flags().StringP("proxy-port", "P", "9443", "Port of the mTLS proxy specified with proxy-host.")
+	cmd.Flags().String("proxy-ca-file", "/konnectivity-proxy/ca/ca.crt", "the path to the CA file for checking the mTLS proxy server certificate")
+	cmd.Flags().String("proxy-client-crt-file", "/konnectivity-proxy/client/tls.crt", "the path to the proxy client certificate used to authenticate to the mTLS proxy server")
 	cmd.Flags().String("proxy-client-key-file", "/konnectivity-proxy/client/tls.key", "the path to the private key file belonging to the proy client certificate")
 
 	err = viper.BindPFlags(cmd.Flags())
@@ -379,9 +379,9 @@ func checkService(opts *Opts, client *k8s.Clientset) error {
 		if targetService != nil { // This means a service was previously seen, and a forwarder should already be running.
 			logger.Infow("Service went away, killing forwarder")
 			killForwarder()
-			if konnectivityProxy != nil { // This means there should be a running proxy, we need to stop it too.
-				konnectivityProxy.DestroyProxy()
-				konnectivityProxy = nil
+			if clusterProxy != nil { // This means there should be a running proxy, we need to stop it too.
+				clusterProxy.DestroyProxy()
+				clusterProxy = nil
 			}
 			targetService = nil
 		}
@@ -403,9 +403,9 @@ func checkService(opts *Opts, client *k8s.Clientset) error {
 		}
 		// We need to kill the old forwarder
 		killForwarder()
-		if konnectivityProxy != nil { // This means there should be a running proxy, we need to stop it too.
-			konnectivityProxy.DestroyProxy()
-			konnectivityProxy = nil
+		if clusterProxy != nil { // This means there should be a running proxy, we need to stop it too.
+			clusterProxy.DestroyProxy()
+			clusterProxy = nil
 		}
 	}
 
@@ -424,15 +424,15 @@ func checkService(opts *Opts, client *k8s.Clientset) error {
 			return errors.New("Proxy config error")
 		}
 		logger.Infow("Starting proxy", "uds", opts.KonnectivityUDSSocket)
-		konnectivityProxy, err = konnectivityproxy.NewProxyUDS(logger, opts.KonnectivityUDSSocket, serviceIP, servicePort, "127.0.0.1", servicePort)
+		clusterProxy, err = proxy.NewProxyUDS(logger, opts.KonnectivityUDSSocket, serviceIP, servicePort, "127.0.0.1", servicePort)
 		if err != nil {
 			logger.Errorw("Could not start UDS proxy", "error", err)
 			return err
 		}
 		fluentTargetIP = "127.0.0.1"
-	} else if opts.ProxyHost != "" { // This means we need to start a konnectivity mTLS proxy
+	} else if opts.ProxyHost != "" { // This means we need to start a mTLS proxy
 		logger.Infow("Starting proxy", "host", opts.ProxyHost, "port", opts.ProxyPort)
-		konnectivityProxy, err = konnectivityproxy.NewProxyMTLS(logger, opts.ProxyHost, opts.ProxyPort, opts.ProxyClientCrtFile, opts.ProxyClientKeyFile, opts.ProxyCaFile, serviceIP, servicePort, "127.0.0.1", servicePort)
+		clusterProxy, err = proxy.NewProxyMTLS(logger, opts.ProxyHost, opts.ProxyPort, opts.ProxyClientCrtFile, opts.ProxyClientKeyFile, opts.ProxyCaFile, serviceIP, servicePort, "127.0.0.1", servicePort)
 		if err != nil {
 			logger.Errorw("Could not start mTLS proxy", "error", err)
 			return err

--- a/main.go
+++ b/main.go
@@ -392,7 +392,7 @@ func checkService(opts *Opts, client *k8s.Clientset) error {
 	serviceIP := service.Spec.ClusterIP
 	if len(service.Spec.Ports) != 1 {
 		logger.Errorw("Service must have exactly one port", "Ports", service.Spec.Ports)
-		return errors.New("Service must have exactly one port")
+		return errors.New("service must have exactly one port")
 	}
 	servicePort := strconv.Itoa(int(service.Spec.Ports[0].Port))
 
@@ -421,7 +421,7 @@ func checkService(opts *Opts, client *k8s.Clientset) error {
 	if opts.KonnectivityUDSSocket != "" { // This means we need to start a konnectivity UDS proxy
 		if opts.ProxyHost != "" {
 			logger.Errorw("konnectivityproxy configuration error, both UDS and proxy host defined. This code should never be reached.", "konnectivity-uds-socket", opts.KonnectivityUDSSocket, "proxy-host", opts.ProxyHost)
-			return errors.New("Proxy config error")
+			return errors.New("proxy config error")
 		}
 		logger.Infow("Starting proxy", "uds", opts.KonnectivityUDSSocket)
 		clusterProxy, err = proxy.NewProxyUDS(logger, opts.KonnectivityUDSSocket, serviceIP, servicePort, "127.0.0.1", servicePort)

--- a/main.go
+++ b/main.go
@@ -141,9 +141,9 @@ func init() {
 	cmd.Flags().StringP("konnectivity-uds-socket", "u", "", "If set, try and connect through this konnectivity UDS socket. Expected method is http-connect. Mutually exclusive with proxy-host.")
 	cmd.Flags().StringP("proxy-host", "p", "", "If set, try and connect through this mTLS proxy at the given destination. Expected method is http-connect. Mutually exclusive with konectivity-uds-socket.")
 	cmd.Flags().StringP("proxy-port", "P", "9443", "Port of the mTLS proxy specified with proxy-host.")
-	cmd.Flags().String("proxy-ca-file", "/konnectivity-proxy/ca/ca.crt", "the path to the CA file for checking the mTLS proxy server certificate")
-	cmd.Flags().String("proxy-client-crt-file", "/konnectivity-proxy/client/tls.crt", "the path to the proxy client certificate used to authenticate to the mTLS proxy server")
-	cmd.Flags().String("proxy-client-key-file", "/konnectivity-proxy/client/tls.key", "the path to the private key file belonging to the proy client certificate")
+	cmd.Flags().String("proxy-ca-file", "/proxy/ca/ca.crt", "the path to the CA file for checking the mTLS proxy server certificate")
+	cmd.Flags().String("proxy-client-crt-file", "/proxy/client/tls.crt", "the path to the proxy client certificate used to authenticate to the mTLS proxy server")
+	cmd.Flags().String("proxy-client-key-file", "/proxy/client/tls.key", "the path to the private key file belonging to the proy client certificate")
 
 	err = viper.BindPFlags(cmd.Flags())
 	if err != nil {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1,5 +1,5 @@
 /*
-Helper package for opening a http connect proxy connection through konnectivity proxy;
+Helper package for opening a http connect proxy connection to tunnel audit data to the cluster;
 either a uds socket or a mTLS proxy, and
 open a listener and forward connections through the proxy connection.
 
@@ -8,7 +8,7 @@ Go TCP Proxy pattern:
 https://gist.github.com/jbardin/821d08cb64c01c84b81a
 */
 
-package konnectivityproxy
+package proxy
 
 import (
 	"bufio"
@@ -128,7 +128,7 @@ func (p *Proxy) handleConnection(srvConn *net.TCPConn) {
 	var proxyConn net.Conn
 	if p.uds != "" {
 		if p.proxyHost != "" {
-			p.logger.Errorw("konnectivityproxy configuration error, both UDS and proxy host defined. This code should never be reached.", "UDS", p.uds, "proxy host", p.proxyHost)
+			p.logger.Errorw("proxy configuration error, both UDS and proxy host defined. This code should never be reached.", "UDS", p.uds, "proxy host", p.proxyHost)
 			return
 		}
 		var err error


### PR DESCRIPTION
mTLS proxy is not necessarily a konnectivity proxy any more; it can also be from using the Gardener reversed-vpn feature.
This PR reflects that and changes the proxy options to be more generic.